### PR TITLE
Added region support for plumbum.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 *.pyc
 
+*.swp
+
 
 # Private User Data
 .env

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -1,4 +1,8 @@
 # Sample config.yaml
+
+# If connecting to a different region other than default, set region
+Auth:
+  region: "us-west-2"
 Metrics:
 - Namespace: "AWS/ELB"
   MetricName: "RequestCount"

--- a/config.yaml.j2.example
+++ b/config.yaml.j2.example
@@ -1,10 +1,13 @@
 {# This is a Jinja2 comment
   To use this template, you'd run something like:
-  python plumbum.py config.yaml.j2.example ec2
+  python plumbum.py config.yaml.j2.example ec2 us-west-2
  #}
 # Sample config.yaml
+#
+Auth:
+  region: "{{ region }}"
 Metrics:
-{% for instance in resources %}
+{%- for instance in resources %}
 - Namespace: "AWS/EC2"
   MetricName: "CPUUtilization"
   Statistics:
@@ -17,4 +20,4 @@ Metrics:
     {# I'm assuming my tag names are safe to use as metric names here #}
     Formatter: 'cloudwatch.%(Namespace)s.{{ instance.tags['Name'] }}.%(MetricName)s.%(statistic)s.%(Unit)s'
     Period: 5
-{% endfor %}
+{%- endfor %}


### PR DESCRIPTION
I made a first pass at adding region support to plumbum, trying to keep it as simple as possible. I added Auth section to example config files, because I found I needed it in the config when connecting to a different region other than us-east-1. The '{%-' changes in config.yaml.j2.example remove the extra line from the template generation. Finally, I added *.swp to .gitignore to remove vim swp backup files from the git status.
