### PR TITLE
Adding support for kinesis application metrics

### DIFF
--- a/plumbum.py
+++ b/plumbum.py
@@ -41,7 +41,7 @@ import boto.ec2.autoscale
 import boto.kinesis
 import boto.sqs
 import jinja2
-
+import os.path
 
 __version__ = '0.5.0'
 
@@ -192,9 +192,10 @@ def main():
     template, namespace, region, filters, __ = interpret_options(sys.argv[1:])
 
     # get the template first so this can fail before making a network request
-    loader = jinja2.FileSystemLoader('.')
+    fs_path = os.path.abspath(os.path.dirname(template))
+    loader = jinja2.FileSystemLoader(fs_path)
     jinja2_env = jinja2.Environment(loader=loader)
-    template = jinja2_env.get_template(template)
+    template = jinja2_env.get_template(os.path.basename(template))
 
     # insure a valid region is set
     if not region in [r.name for r in boto.ec2.regions()]:

--- a/plumbum.py
+++ b/plumbum.py
@@ -38,6 +38,7 @@ import boto.ec2.elb
 import boto.rds
 import boto.elasticache
 import boto.ec2.autoscale
+import boto.kinesis
 import boto.sqs
 import jinja2
 
@@ -156,6 +157,19 @@ def list_sqs(region, filter_by_kwargs):
     return lookup(queues, filter_by=filter_by_kwargs)
 
 
+def list_kinesis_applications(region, filter_by_kwargs):
+    """List all the kinesis applications along with the shards for each stream"""
+    conn = boto.kinesis.connect_to_region(region)
+    streams = conn.list_streams()['StreamNames']
+    kinesis_streams = {}
+    for stream_name in streams:
+        shard_ids = []
+        shards = conn.describe_stream(stream_name)['StreamDescription']['Shards']
+        for shard in shards:
+            shard_ids.append(shard['ShardId'])
+        kinesis_streams[stream_name] = shard_ids
+    return kinesis_streams
+
 list_resources = {
     'ec2': list_ec2,
     'elb': list_elb,
@@ -163,6 +177,7 @@ list_resources = {
     'elasticache': list_elasticache,
     'asg': list_autoscaling_group,
     'sqs': list_sqs,
+    'kinesisapp': list_kinesis_applications,
 }
 
 

--- a/sample_templates/kinesisapp.yml.js
+++ b/sample_templates/kinesisapp.yml.js
@@ -1,0 +1,31 @@
+{%- set metrics = {'DataBytesProcessed': {'stat': 'Average', 'unit': 'Bytes'},
+                   'KinesisDataFetcher.getRecords.Success': {'stat': 'Average', 'unit': 'Count'},
+                   'KinesisDataFetcher.getRecords.Time': {'stat': 'Average', 'unit': 'Milliseconds'},
+                   'MillisBehindLatest': {'stat': 'Average', 'unit': 'Milliseconds'},
+                   'RecordsProcessed': {'stat': 'Average', 'unit': 'Count'},
+                   'Success': {'stat': 'Average', 'unit': 'Count'},
+                   'Time': {'stat': 'Average', 'unit': 'Milliseconds'},
+                   'UpdateLease.Success': {'stat': 'Average', 'unit': 'Count'},
+                   'UpdateLease.Time': {'stat': 'Average', 'unit': 'Milliseconds'}
+                   } -%}
+
+# If connecting to a different region other than default, set region
+Auth:
+  region: "{{ region }}"
+Metrics:
+{%- for stream_name, shards in resources.iteritems() %}
+  {%- for shard in shards %}
+    {%- for metric in metrics %}
+- Namespace: "kinesis-application-name"
+  MetricName: "{{ metric }}"
+  Statistics: "{{ metrics[metric]['stat'] }}"
+  Unit: "{{ metrics[metric]['unit'] }}"
+  Dimensions:
+    ShardId: "{{ shard }}"
+    Operation: "ProcessTask"
+  Options:
+    Formatter: 'cloudwatch.{{ stream_name}}.%(Namespace)s.%(MetricName)s.{{ shard }}.%(statistic)s.%(Unit)s'
+    Period: 5
+     {% endfor %}
+   {% endfor %}
+{% endfor %}


### PR DESCRIPTION
- Adding another template support for pulling metrics for
    kinesis applications. Kinesis applications cannot be
    "discovered" so they can't be parameterized and they
    have to be known in advance. In other words, the namespace
    field has to be filled out. The template however can discover
    all the shards and streams that are available.

- Make jinja load its file system based on where the config
    file is. It's not necessarily true that the config file
    will live under the same directory as plumbum