### PR TITLE
Allow for per-metric definition of formatter

### DIFF
--- a/leadbutt.py
+++ b/leadbutt.py
@@ -89,7 +89,10 @@ def output_results(results, metric, options):
 
     TODO: add AMPQ support for efficiency
     """
-    formatter = options['Formatter']
+    try:
+        formatter = metric['Formatter']
+    except KeyError:
+        formatter = options['Formatter']
     context = metric.copy()  # XXX might need to sanitize this
     try:
         context['dimension'] = list(metric['Dimensions'].values())[0]


### PR DESCRIPTION
Allows declaration of a yaml-wide formatter but still permit each metric to use
its own formatter.

Useful if we want to customize the metric names depending on the type of metric
requested.

e.g.:

```
- Namespace: "AWS/DynamoDB"
  MetricName: "SuccessfulRequestLatency"
  Statistics: "Average"
  Dimensions:
    TableName: "DeviceEvent"
    Operation: "Query"
  Unit: "Milliseconds"
- Namespace: "AWS/DynamoDB"
  MetricName: "ProvisionedWriteCapacityUnits"
  Statistics: "SampleCount"
  Dimensions:
    TableName: "PlaybackStream"
  Unit: "Count"
  Formatter: 'cloudwatch.%(Namespace)s.table-%(dimension)s.%(MetricName)s.%(Unit)s'
Options:
  Formatter: 'cloudwatch.%(Namespace)s.%(dimension)s.%(MetricName)s.%(statistic)s.%(Unit)s'
  Period: 5
  Count: 1
```

The metric ```ProvisionedWriteCapacityUnits``` will be output using the extra
```.table-``` in the string